### PR TITLE
Support Web3 Keystore compatibility (with backward compatibility)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,7 @@
 .DS_Store
 
 # Distribution folders
-dist/*.js
-dist/*.json
+dist
 lib
 
 # Dependency directories

--- a/src/crypto/index.js
+++ b/src/crypto/index.js
@@ -209,7 +209,7 @@ const generateKeyStore = (privateKeyHex, password = '') => {
   }
 
   const cipherText = Buffer.concat([cipher.update(Buffer.from(privateKeyHex, 'hex')), cipher.final()]);
-  const bufferValue = Buffer.concat([derivedKey.slice(16, 32), Buffer.from(cipherText)]);
+  const bufferValue = Buffer.concat([derivedKey.slice(16, 32), cipherText]);
 
   return {
     version: 3,

--- a/src/utils/base.js
+++ b/src/utils/base.js
@@ -225,15 +225,16 @@ const sha256 = (hex) => {
 };
 
 /**
- * Computes a single SHA3 (Keccak) digest.
+ * Computes a single SHA3-Keccak digest.
  * @param {string} hex message to hash
+ * @param {number} outputLength output length in bits (224, 256, 384, or 512)
  * @returns {string} hash output
  */
-const sha3 = (hex) => {
-  if (!is.string(hex)) throw new Error('sha3 expects a hex string');
+const sha3keccak = (hex, outputLength) => {
+  if (!is.string(hex)) throw new Error('sha3keccak expects a hex string');
   if (hex.length % 2 !== 0) throw new Error(`invalid hex string length: ${hex}`);
   const hexEncoded = hexEncoding.parse(hex);
-  return SHA3(hexEncoded).toString();
+  return SHA3(hexEncoded, { outputLength: outputLength }).toString();
 };
 
 export {
@@ -253,5 +254,5 @@ export {
   ensureHex,
   sha256ripemd160,
   sha256,
-  sha3,
+  sha3keccak,
 }

--- a/test/crypto/index.ts
+++ b/test/crypto/index.ts
@@ -41,6 +41,10 @@ describe('crypto', () => {
       const jsonStr = fs.readFileSync(`${__dirname}/testdata/keystore_legacy.json`).toString();
       expect(crypto.getPrivateKeyFromKeyStore(JSON.parse(jsonStr), 'testpassword')).to.be.eql('cb011405894895c814432f1556b52bb054720a9b2a6ffaf3792a45f911b50dff');
     });
+    it('get private key from the old legacy format which uses aes-256-ctr and sha1-256', () => {
+      const jsonStr = fs.readFileSync(`${__dirname}/testdata/keystore_old_legacy.json`).toString();
+      expect(crypto.getPrivateKeyFromKeyStore(JSON.parse(jsonStr), 'testpassword')).to.be.eql('83bf913f1ef05c242a60784eaaf90576aaf664ed9c834cff9018bbd8ba92cd66');
+    });
   });
 
   describe('generateMnemonic', () => {

--- a/test/crypto/index.ts
+++ b/test/crypto/index.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { expect } from 'chai';
 import * as bip39 from 'bip39';
 import { PRIVKEY_LEN, PRIVKEY_MAX } from '../../src/config/default';
@@ -26,10 +27,19 @@ describe('crypto', () => {
   });
 
   describe('getPrivateKeyFromKeyStore', () => {
-    it('generates private key from key store', () => {
+    it('get private key from key store', () => {
       const keyStore = crypto.generateKeyStore(sample.privateKey, 'password123');
       expect(() => crypto.getPrivateKeyFromKeyStore(keyStore, '')).to.throw();
       expect(crypto.getPrivateKeyFromKeyStore(keyStore, 'password123')).to.be.eql(sample.privateKey);
+    });
+    it('get private key from the Web3 Secret Storage standard format', () => {
+      // the standard test case is from https://github.com/ethereum/wiki/wiki/Web3-Secret-Storage-Definition#test-vectors
+      const jsonStr = fs.readFileSync(`${__dirname}/testdata/keystore_web3.json`).toString();
+      expect(crypto.getPrivateKeyFromKeyStore(JSON.parse(jsonStr), 'testpassword')).to.be.eql('7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d');
+    });
+    it('get private key from the legacy format which uses aes-256-ctr and sha3-keccak512', () => {
+      const jsonStr = fs.readFileSync(`${__dirname}/testdata/keystore_legacy.json`).toString();
+      expect(crypto.getPrivateKeyFromKeyStore(JSON.parse(jsonStr), 'testpassword')).to.be.eql('cb011405894895c814432f1556b52bb054720a9b2a6ffaf3792a45f911b50dff');
     });
   });
 

--- a/test/crypto/testdata/keystore_legacy.json
+++ b/test/crypto/testdata/keystore_legacy.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "id": "c88920bc-b6bb-48ca-b500-4a31a4c2964f",
+  "crypto": {
+    "ciphertext": "ef04495d876e7aa5af6dd09e47af48300d971d4154ffd1858b83b37601ee751f",
+    "cipherparams": {
+      "iv": "9774a7a25f1426707d1d00b966533fb2"
+    },
+    "cipher": "aes-256-ctr",
+    "kdf": "pbkdf2",
+    "kdfparams": {
+      "dklen": 32,
+      "salt": "52f669bf68efd474cfb66aff4f62ec21599e0de23dbb4fec0c7cccb5666648cb",
+      "c": 262144,
+      "prf": "hmac-sha256"
+    },
+    "mac": "065bd7f341388de3ce221a293df8154433c7ca57522252e143ce49b6462201e57d3e5ce00b44bb32147916537ae03d3488d3623512f5a4348e52e1f34c13e4a2"
+  }
+}

--- a/test/crypto/testdata/keystore_old_legacy.json
+++ b/test/crypto/testdata/keystore_old_legacy.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "id": "19723c2d-2fb4-41b2-9789-5d56934c47c0",
+  "crypto": {
+    "ciphertext": "3246c7eca75214116cb1f0d678efd6b25b62b2570caf3280aebcc4ad34fb6e49",
+    "cipherparams": {
+      "iv": "30780ab0fd14cd76c1c4fcc872dd8b87"
+    },
+    "cipher": "aes-256-ctr",
+    "kdf": "pbkdf2",
+    "kdfparams": {
+      "dklen": 32,
+      "salt": "a90479b4021bc963b9604fec4c27ff16ea79f33104c927671e4d450ce0858c59",
+      "c": 262144,
+      "prf": "hmac-sha256"
+    },
+    "mac": "afd03d0444ca3e4bad7720627803affb12948783c923a7149561302f9fd62ffb"
+  }
+}

--- a/test/crypto/testdata/keystore_web3.json
+++ b/test/crypto/testdata/keystore_web3.json
@@ -1,0 +1,19 @@
+{
+  "version": 3,
+  "id": "3198bc9c-6672-5ab3-d995-4942343ae5b6",
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "cipherparams": {
+      "iv": "6087dab2f9fdbbfaddc31a909735c1e6"
+    },
+    "ciphertext": "5318b4d5bcd28de64ee5559e671353e16f075ecae9f99c7a79a38af5f869aa46",
+    "kdf": "pbkdf2",
+    "kdfparams": {
+      "c": 262144,
+      "dklen": 32,
+      "prf": "hmac-sha256",
+      "salt": "ae3cd4e7013836a3df6bd7241b12db061dbe2c6785853cce422d148a624ce0bd"
+    },
+    "mac": "517ead924a9d0dc3124507e3393d175ce3ff7c1e96529c6c555ce9e51205e9b2"
+  }
+}


### PR DESCRIPTION
Close #6 

Now, we can accept all of these formats:
- The Web3 standard which uses `version: 3`, `aes-128-ctr` and `sha3-keccak256`.
- The legacy which uses `version: 1`, `aes-256-ctr` and `sha3-keccak512`.
- The old legacy which uses `versions: 1`, `aes-265-ctr` and `sha1-256`.

