### PR TITLE
Use proper value types for DID messages

### DIFF
--- a/src/config/test.js
+++ b/src/config/test.js
@@ -1,4 +1,5 @@
 import { PARAM } from './default';
+import { DIDDocument, DIDPubKey } from '../message/DID';
 
 export const DEFAULT_DENOM = 'umed';
 
@@ -71,14 +72,34 @@ export const MESSAGE = {
   DID: {
     CREATE_DID: {
       did: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-      document: '{"id":"did:panacea:testnet:LfBBguz7sBppPUrAsvTzd","publicKey":[{"id":"did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2","type":"Secp256k1VerificationKey2018","publicKeyBase58":"pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D"}],"authentication":["did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2"]}',
+      document: new DIDDocument({
+        id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
+        publicKey: [
+          new DIDPubKey({
+            id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
+            type: 'Secp256k1VerificationKey2018',
+            publicKeyBase58: 'pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D',
+          }),
+        ],
+        authentication: ['did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2'],
+      }),
       sigKeyId: 'did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh#key1',
       signature: 'asdfkljaslkfdjdlsk',
       fromAddress: ACCOUNT.address,
     },
     UPDATE_DID: {
       did: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-      document: '{"id":"did:panacea:testnet:LfBBguz7sBppPUrAsvTzd","publicKey":[{"id":"did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2","type":"Secp256k1VerificationKey2018","publicKeyBase58":"pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D"}],"authentication":["did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2"]}',
+      document: new DIDDocument({
+        id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
+        publicKey: [
+          new DIDPubKey({
+            id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
+            type: 'Secp256k1VerificationKey2018',
+            publicKeyBase58: 'pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D',
+          }),
+        ],
+        authentication: ['did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2'],
+      }),
       sigKeyId: 'did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh#key1',
       signature: 'asdfkljaslkfdjdlsk',
       fromAddress: ACCOUNT.address,

--- a/src/utils/did.js
+++ b/src/utils/did.js
@@ -25,6 +25,7 @@ export const generateDIDDocument = (networkID, keyIDSuffix, pubKeyHex) => {
   });
 
   return new DIDDocument({
+    context: 'https://www.w3.org/ns/did/v1',
     id: did,
     publicKey: [didPubKey],
     authentication: [didPubKey.id],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -369,7 +369,7 @@ export namespace Message {
       type: 'did/MsgCreateDID';
       value: {
         did: string;
-        document: string;
+        document: DIDDocument;
         sig_key_id: string;
         signature: string;
         from_address: string;
@@ -377,7 +377,7 @@ export namespace Message {
 
       constructor(data: {
         did: string;
-        document: string;
+        document: DIDDocument;
         sigKeyId: string;
         signature: string;
         fromAddress: string;
@@ -388,7 +388,7 @@ export namespace Message {
       type: 'did/MsgUpdateDID';
       value: {
         did: string;
-        document: string;
+        document: DIDDocument;
         sig_key_id: string;
         signature: string;
         from_address: string;
@@ -396,7 +396,7 @@ export namespace Message {
 
       constructor(data: {
         did: string;
-        document: string;
+        document: DIDDocument;
         sigKeyId: string;
         signature: string;
         fromAddress: string;
@@ -417,6 +417,30 @@ export namespace Message {
         sigKeyId: string;
         signature: string;
         fromAddress: string;
+      })
+    }
+
+    class DIDDocument {
+      id: string;
+      publicKey: DIDPubKey[];
+      authentication: string[];
+
+      constructor(data: {
+        id: string;
+        publicKey: DIDPubKey[];
+        authentication: string[];
+      })
+    }
+
+    class DIDPubKey {
+      id: string;
+      type: string;
+      publicKeyBase58: string;
+
+      constructor(data: {
+        id: string;
+        type: string;
+        publicKeyBase58: string;
       })
     }
   }


### PR DESCRIPTION
Previously, the `document` field in DID messages was `string` (in `index.d.ts`). I changed it to the `DIDDocument` type.