### PR TITLE
Follow up the latest DID spec: @context, verificationMethod, controller, authentication

### DIFF
--- a/example/did.js
+++ b/example/did.js
@@ -40,7 +40,7 @@ async function createDID(account, keystore) {
   const msg = new panaceajs.Message.DID.CreateDID({
     did: didDoc.id,
     document: didDoc,
-    sigKeyId: didDoc.publicKey[0].id,
+    verificationMethodId: didDoc.verificationMethod[0].id,
     signature: sig,
     fromAddress: account.address,
   });
@@ -79,7 +79,7 @@ async function updateDID(account, keystore, did, keyId, newDoc) {
   const msg = new panaceajs.Message.DID.UpdateDID({
     did,
     document: newDoc,
-    sigKeyId: keyId,
+    verificationMethodId: keyId,
     signature: sig,
     fromAddress: account.address,
   });
@@ -111,7 +111,7 @@ async function deactivateDID(account, keystore, did, keyId) {
 
   const msg = new panaceajs.Message.DID.DeactivateDID({
     did,
-    sigKeyId: keyId,
+    verificationMethodId: keyId,
     signature: sig,
     fromAddress: account.address,
   });
@@ -134,7 +134,7 @@ async function main() {
     const doc = await getDID(did);
     console.log(doc);
 
-    const keyId = doc.publicKey[0].id;
+    const keyId = doc.verificationMethod[0].id;
     const newDoc = doc;
     newDoc.authentication.push(keyId); // just for testing, push the same keyId again.
     await updateDID(account, keystore, did, keyId, newDoc);

--- a/src/config/test.js
+++ b/src/config/test.js
@@ -1,5 +1,4 @@
 import { PARAM } from './default';
-import { DIDDocument, DIDPubKey } from '../message/DID';
 
 export const DEFAULT_DENOM = 'umed';
 
@@ -72,41 +71,41 @@ export const MESSAGE = {
   DID: {
     CREATE_DID: {
       did: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-      document: new DIDDocument({
+      document: {
         id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-        publicKey: [
-          new DIDPubKey({
-            id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
-            type: 'Secp256k1VerificationKey2018',
-            publicKeyBase58: 'pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D',
-          }),
-        ],
+        verificationMethod: [{
+          '@context': 'https://www.w3.org/ns/did/v1',
+          id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
+          type: 'Secp256k1VerificationKey2018',
+          controller: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
+          publicKeyBase58: 'pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D',
+        }],
         authentication: ['did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2'],
-      }),
-      sigKeyId: 'did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh#key1',
+      },
+      verificationMethodId: 'did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh#key1',
       signature: 'asdfkljaslkfdjdlsk',
       fromAddress: ACCOUNT.address,
     },
     UPDATE_DID: {
       did: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-      document: new DIDDocument({
+      document: {
         id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-        publicKey: [
-          new DIDPubKey({
-            id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
-            type: 'Secp256k1VerificationKey2018',
-            publicKeyBase58: 'pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D',
-          }),
-        ],
+        verificationMethod: [{
+          '@context': 'https://www.w3.org/ns/did/v1',
+          id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
+          type: 'Secp256k1VerificationKey2018',
+          controller: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
+          publicKeyBase58: 'pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D',
+        }],
         authentication: ['did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2'],
-      }),
-      sigKeyId: 'did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh#key1',
+      },
+      verificationMethodId: 'did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh#key1',
       signature: 'asdfkljaslkfdjdlsk',
       fromAddress: ACCOUNT.address,
     },
     DEACTIVATE_DID: {
       did: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-      sigKeyId: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
+      verificationMethodId: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
       signature: 'asdfkljaslkfdjdlsk',
       fromAddress: ACCOUNT.address,
     },

--- a/src/message/DID.js
+++ b/src/message/DID.js
@@ -5,14 +5,14 @@ const { DID } = MSG_TYPE;
 
 class CreateDID {
   constructor(data) {
-    const requiredParams = ['did', 'document', 'sigKeyId', 'signature', 'fromAddress'];
+    const requiredParams = ['did', 'document', 'verificationMethodId', 'signature', 'fromAddress'];
     checkParams(requiredParams, data);
 
     this.type = DID.CREATE_DID;
     this.value = {
       did: data.did,
       document: data.document,
-      sig_key_id: data.sigKeyId,
+      verification_method_id: data.verificationMethodId,
       signature: data.signature,
       from_address: data.fromAddress,
     };
@@ -21,14 +21,14 @@ class CreateDID {
 
 class UpdateDID {
   constructor(data) {
-    const requiredParams = ['did', 'document', 'sigKeyId', 'signature', 'fromAddress'];
+    const requiredParams = ['did', 'document', 'verificationMethodId', 'signature', 'fromAddress'];
     checkParams(requiredParams, data);
 
     this.type = DID.UPDATE_DID;
     this.value = {
       did: data.did,
       document: data.document,
-      sig_key_id: data.sigKeyId,
+      verification_method_id: data.verificationMethodId,
       signature: data.signature,
       from_address: data.fromAddress,
     };
@@ -37,32 +37,16 @@ class UpdateDID {
 
 class DeactivateDID {
   constructor(data) {
-    const requiredParams = ['did', 'sigKeyId', 'signature', 'fromAddress'];
+    const requiredParams = ['did', 'verificationMethodId', 'signature', 'fromAddress'];
     checkParams(requiredParams, data);
 
     this.type = DID.DEACTIVATE_DID;
     this.value = {
       did: data.did,
-      sig_key_id: data.sigKeyId,
+      verification_method_id: data.verificationMethodId,
       signature: data.signature,
       from_address: data.fromAddress,
     };
-  }
-}
-
-class DIDDocument {
-  constructor(data) {
-    this.id = data.id;
-    this.publicKey = data.publicKey;
-    this.authentication = data.authentication;
-  }
-}
-
-class DIDPubKey {
-  constructor(data) {
-    this.id = data.id;
-    this.type = data.type;
-    this.publicKeyBase58 = data.publicKeyBase58;
   }
 }
 
@@ -72,7 +56,5 @@ export {
   CreateDID,
   UpdateDID,
   DeactivateDID,
-  DIDDocument,
-  DIDPubKey,
   InitialSequence,
 };

--- a/src/utils/did.js
+++ b/src/utils/did.js
@@ -1,4 +1,3 @@
-import { DIDDocument, DIDPubKey } from '../message/DID';
 import { sortJsonProperties } from './encoding';
 import { generateSignatureFromHash } from '../crypto';
 import { sha256 } from './base';
@@ -18,17 +17,19 @@ export const generateDIDDocument = (networkID, keyIDSuffix, pubKeyHex) => {
   const pubKeyBuf = Buffer.from(pubKeyHex, 'hex');
 
   const did = generateDID(networkID, pubKeyBuf);
-  const didPubKey = new DIDPubKey({
+  const didPubKey = {
     id: `${did}#${keyIDSuffix}`,
     type: keyType,
+    controller: did,
     publicKeyBase58: bs58.encode(pubKeyBuf),
-  });
+  };
 
-  return new DIDDocument({
+  return {
+    '@context': 'https://www.w3.org/ns/did/v1',
     id: did,
-    publicKey: [didPubKey],
+    verificationMethod: [didPubKey],
     authentication: [didPubKey.id],
-  });
+  };
 };
 
 export const sign = (data, seq, privKey) => {

--- a/test/message/DID.ts
+++ b/test/message/DID.ts
@@ -12,7 +12,7 @@ describe('DID message', () => {
       expect(msg.type).to.be.equal(config.MSG_TYPE.DID.CREATE_DID);
       expect(msg.value.did).to.be.equal(test.MESSAGE.DID.CREATE_DID.did);
       expect(msg.value.document).to.be.equal(test.MESSAGE.DID.CREATE_DID.document);
-      expect(msg.value.sig_key_id).to.be.equal(test.MESSAGE.DID.CREATE_DID.sigKeyId);
+      expect(msg.value.verification_method_id).to.be.equal(test.MESSAGE.DID.CREATE_DID.verificationMethodId);
       expect(msg.value.signature).to.be.equal(test.MESSAGE.DID.CREATE_DID.signature);
       expect(msg.value.from_address).to.be.equal(test.MESSAGE.DID.CREATE_DID.fromAddress);
     });
@@ -25,7 +25,7 @@ describe('DID message', () => {
       expect(msg.type).to.be.equal(config.MSG_TYPE.DID.UPDATE_DID);
       expect(msg.value.did).to.be.equal(test.MESSAGE.DID.UPDATE_DID.did);
       expect(msg.value.document).to.be.equal(test.MESSAGE.DID.UPDATE_DID.document);
-      expect(msg.value.sig_key_id).to.be.equal(test.MESSAGE.DID.UPDATE_DID.sigKeyId);
+      expect(msg.value.verification_method_id).to.be.equal(test.MESSAGE.DID.UPDATE_DID.verificationMethodId);
       expect(msg.value.signature).to.be.equal(test.MESSAGE.DID.UPDATE_DID.signature);
       expect(msg.value.from_address).to.be.equal(test.MESSAGE.DID.UPDATE_DID.fromAddress);
     });
@@ -37,7 +37,7 @@ describe('DID message', () => {
 
       expect(msg.type).to.be.equal(config.MSG_TYPE.DID.DEACTIVATE_DID);
       expect(msg.value.did).to.be.equal(test.MESSAGE.DID.DEACTIVATE_DID.did);
-      expect(msg.value.sig_key_id).to.be.equal(test.MESSAGE.DID.DEACTIVATE_DID.sigKeyId);
+      expect(msg.value.verification_method_id).to.be.equal(test.MESSAGE.DID.DEACTIVATE_DID.verificationMethodId);
       expect(msg.value.signature).to.be.equal(test.MESSAGE.DID.DEACTIVATE_DID.signature);
       expect(msg.value.from_address).to.be.equal(test.MESSAGE.DID.DEACTIVATE_DID.fromAddress);
     });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -369,16 +369,16 @@ export namespace Message {
       type: 'did/MsgCreateDID';
       value: {
         did: string;
-        document: DIDDocument;
-        sig_key_id: string;
+        document: Record<string, any>;
+        verification_method_id: string;
         signature: string;
         from_address: string;
       }
 
       constructor(data: {
         did: string;
-        document: DIDDocument;
-        sigKeyId: string;
+        document: Record<string, any>;
+        verificationMethodId: string;
         signature: string;
         fromAddress: string;
       })
@@ -388,16 +388,16 @@ export namespace Message {
       type: 'did/MsgUpdateDID';
       value: {
         did: string;
-        document: DIDDocument;
-        sig_key_id: string;
+        document: Record<string, any>;
+        verification_method_id: string;
         signature: string;
         from_address: string;
       }
 
       constructor(data: {
         did: string;
-        document: DIDDocument;
-        sigKeyId: string;
+        document: Record<string, any>;
+        verificationMethodId: string;
         signature: string;
         fromAddress: string;
       })
@@ -407,40 +407,16 @@ export namespace Message {
       type: 'did/MsgDeactivateDID';
       value: {
         did: string;
-        sig_key_id: string;
+        verification_method_id: string;
         signature: string;
         from_address: string;
       }
 
       constructor(data: {
         did: string;
-        sigKeyId: string;
+        verificationMethodId: string;
         signature: string;
         fromAddress: string;
-      })
-    }
-
-    class DIDDocument {
-      id: string;
-      publicKey: DIDPubKey[];
-      authentication: string[];
-
-      constructor(data: {
-        id: string;
-        publicKey: DIDPubKey[];
-        authentication: string[];
-      })
-    }
-
-    class DIDPubKey {
-      id: string;
-      type: string;
-      publicKeyBase58: string;
-
-      constructor(data: {
-        id: string;
-        type: string;
-        publicKeyBase58: string;
       })
     }
   }


### PR DESCRIPTION
Close #9 

Refer to https://github.com/medibloc/panacea-core/pull/44, https://github.com/medibloc/panacea-core/pull/45

I wanted to switch to Typescript, because `DIDDocument` class is getting complicated and we need some [custom transformations](https://github.com/medibloc/panacea-core/blob/25c4cdb326b97cb317495f7e7db36daf10b21aec/x/did/types/did.go#L347) for JSON marshaling/unmarshaling.
I've tried to use `class-transformer` for Javascript, but I didn't make it. It seems it's for Typescript.

So, in this PR, I gave up having the class: `DIDDocument`. I made it as a plain object.
The validation check would be done by `panacea-core`.

This is the same strategy as AOL. The AOL `Topic` isn't defined in this JS SDK.

Please let me know if you have a good idea. 

As a next step, we should switch to Typescript and have concrete types.
Here's a WIP branch: https://github.com/medibloc/panacea-js/tree/ft/na/ts