### PR TITLE
[Typescript] Better HTTP error handling with Axios interceptor

### DIFF
--- a/example/did.js
+++ b/example/did.js
@@ -39,7 +39,7 @@ async function createDID(account, keystore) {
   const msg = new panaceajs.Message.DID.CreateDID({
     did: didDoc.id,
     document: didDoc,
-    sigKeyId: didDoc.publicKey[0].id,
+    verificationMethodId: didDoc.verificationMethod[0].id,
     signature: sig,
     fromAddress: account.address,
   });
@@ -78,7 +78,7 @@ async function updateDID(account, keystore, did, keyId, newDoc) {
   const msg = new panaceajs.Message.DID.UpdateDID({
     did,
     document: newDoc,
-    sigKeyId: keyId,
+    verificationMethodId: keyId,
     signature: sig,
     fromAddress: account.address,
   });
@@ -110,7 +110,7 @@ async function deactivateDID(account, keystore, did, keyId) {
 
   const msg = new panaceajs.Message.DID.DeactivateDID({
     did,
-    sigKeyId: keyId,
+    verificationMethodId: keyId,
     signature: sig,
     fromAddress: account.address,
   });
@@ -133,9 +133,9 @@ async function main() {
     const doc = await getDID(did);
     console.log(doc);
 
-    const keyId = doc.publicKey[0].id;
+    const keyId = doc.verificationMethod[0].id;
     const newDoc = doc;
-    newDoc.authentication.push(keyId); // just for testing, push the same keyId again.
+    newDoc.authentication.push(newDoc.authentication[0]); // just for testing, push the same authentication again
     await updateDID(account, keystore, did, keyId, newDoc);
     console.log(await getDID(did));
 

--- a/src/client/DID.ts
+++ b/src/client/DID.ts
@@ -1,5 +1,7 @@
 import Client from './Client';
 import { APIS } from '../config/default';
+import {DIDDocumentWithSeq} from "../message/DID";
+import {plainToClass} from "class-transformer";
 
 const { DID: DID_API } = APIS;
 
@@ -13,8 +15,11 @@ export default class DID extends Client {
   /**
    * GET
    * */
-  //TODO @youngjoon-lee: use a proper type for Promise
-  getDID(did: string): Promise<any> {
-    return this.getRequest(DID_API.did, [did]);
+  getDID(did: string): Promise<DIDDocumentWithSeq> {
+    return this.getRequest(DID_API.did, [did])
+      .then((data: Record<string, any>): DIDDocumentWithSeq => {
+        //TODO @youngjoon-lee: handle the case when DID was already deactivated
+        return plainToClass(DIDDocumentWithSeq, data, { excludeExtraneousValues: true });
+      });
   }
 }

--- a/src/config/test.ts
+++ b/src/config/test.ts
@@ -1,5 +1,5 @@
 import { PARAM } from './default';
-import { DIDDocument, DIDPubKey } from '../message/DID';
+import {DIDAuthentication, DIDDocument, DIDVerificationMethod} from '../message/DID';
 
 export const DEFAULT_DENOM = 'umed';
 
@@ -31,6 +31,49 @@ export const SIMPLE_TX = {
     ],
     gas: 200000,
   },
+};
+
+export const SIMPLE_DID_DOC = new DIDDocument(
+  ['https://www.w3.org/ns/did/v1'],
+  'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
+  [
+    new DIDVerificationMethod(
+      'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
+      'Secp256k1VerificationKey2018',
+      'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
+      'pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D',
+    ),
+  ],
+  [
+    new DIDAuthentication('did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2'),
+    new DIDAuthentication('did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1', new DIDVerificationMethod(
+      'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
+      'Secp256k1VerificationKey2018',
+      'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
+      'pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D',
+    )),
+  ],
+);
+export const SIMPLE_DID_DOC_PLAIN = {
+  '@context': "https://www.w3.org/ns/did/v1",
+  id: "did:panacea:testnet:LfBBguz7sBppPUrAsvTzd",
+  verificationMethod: [
+    {
+      "id": "did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1",
+      "type": "Secp256k1VerificationKey2018",
+      "controller": "did:panacea:testnet:LfBBguz7sBppPUrAsvTzd",
+      "publicKeyBase58": "pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D"
+    }
+  ],
+  authentication: [
+    "did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2",
+    {
+      "id": "did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1",
+      "type": "Secp256k1VerificationKey2018",
+      "controller": "did:panacea:testnet:LfBBguz7sBppPUrAsvTzd",
+      "publicKeyBase58": "pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D"
+    }
+  ]
 };
 
 export const MESSAGE = {
@@ -72,41 +115,21 @@ export const MESSAGE = {
   DID: {
     CREATE_DID: {
       did: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-      document: new DIDDocument({
-        id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-        publicKey: [
-          new DIDPubKey({
-            id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
-            type: 'Secp256k1VerificationKey2018',
-            publicKeyBase58: 'pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D',
-          }),
-        ],
-        authentication: ['did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2'],
-      }),
-      sigKeyId: 'did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh#key1',
+      document: SIMPLE_DID_DOC,
+      verificationMethodId: 'did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh#key1',
       signature: 'asdfkljaslkfdjdlsk',
       fromAddress: ACCOUNT.address,
     },
     UPDATE_DID: {
       did: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-      document: new DIDDocument({
-        id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-        publicKey: [
-          new DIDPubKey({
-            id: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
-            type: 'Secp256k1VerificationKey2018',
-            publicKeyBase58: 'pHtDjG9XTs1muhzno6qKor3UiK8v994zDoVHLGgT9R8D',
-          }),
-        ],
-        authentication: ['did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key2'],
-      }),
-      sigKeyId: 'did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh#key1',
+      document: SIMPLE_DID_DOC,
+      verificationMethodId: 'did:panacea:mainnet:DnreD8QqXAQaEW9DwC16Wh#key1',
       signature: 'asdfkljaslkfdjdlsk',
       fromAddress: ACCOUNT.address,
     },
     DEACTIVATE_DID: {
       did: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd',
-      sigKeyId: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
+      verificationMethodId: 'did:panacea:testnet:LfBBguz7sBppPUrAsvTzd#key1',
       signature: 'asdfkljaslkfdjdlsk',
       fromAddress: ACCOUNT.address,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import 'reflect-metadata';  // for class-transformer
+
 import Account from './account';
 import Client from './client';
 import Coin, { Fee } from './coin';

--- a/src/message/DID.ts
+++ b/src/message/DID.ts
@@ -1,5 +1,7 @@
 import { MSG_TYPE } from '../config/default';
 import { checkParams } from '../utils/validate';
+import {classToPlain, Expose, plainToClass, Transform, Type} from 'class-transformer';
+const is = require('is_js');
 
 const { DID } = MSG_TYPE;
 
@@ -9,14 +11,14 @@ export class CreateDID {
 
   //TODO @youngjoon-lee: to be type-safe
   constructor(data: Record<string, any>) {
-    const requiredParams = ['did', 'document', 'sigKeyId', 'signature', 'fromAddress'];
+    const requiredParams = ['did', 'document', 'verificationMethodId', 'signature', 'fromAddress'];
     checkParams(requiredParams, data);
 
     this.type = DID.CREATE_DID;
     this.value = {
       did: data.did,
       document: data.document,
-      sig_key_id: data.sigKeyId,
+      verification_method_id: data.verificationMethodId,
       signature: data.signature,
       from_address: data.fromAddress,
     };
@@ -29,14 +31,14 @@ export class UpdateDID {
 
   //TODO @youngjoon-lee: to be type-safe
   constructor(data: Record<string, any>) {
-    const requiredParams = ['did', 'document', 'sigKeyId', 'signature', 'fromAddress'];
+    const requiredParams = ['did', 'document', 'verificationMethodId', 'signature', 'fromAddress'];
     checkParams(requiredParams, data);
 
     this.type = DID.UPDATE_DID;
     this.value = {
       did: data.did,
       document: data.document,
-      sig_key_id: data.sigKeyId,
+      verification_method_id: data.verificationMethodId,
       signature: data.signature,
       from_address: data.fromAddress,
     };
@@ -49,43 +51,132 @@ export class DeactivateDID {
 
   //TODO @youngjoon-lee: to be type-safe
   constructor(data: Record<string, any>) {
-    const requiredParams = ['did', 'sigKeyId', 'signature', 'fromAddress'];
+    const requiredParams = ['did', 'verificationMethodId', 'signature', 'fromAddress'];
     checkParams(requiredParams, data);
 
     this.type = DID.DEACTIVATE_DID;
     this.value = {
       did: data.did,
-      sig_key_id: data.sigKeyId,
+      verification_method_id: data.verificationMethodId,
       signature: data.signature,
       from_address: data.fromAddress,
     };
   }
 }
 
-export class DIDDocument {
-  public id: string;
-  public publicKey: Record<string, any>[]; //TODO @youngjoon-lee: use the DIDPubKey export class
-  public authentication: string[];
+/**
+ * The return-type of the DID GET operation
+ */
+export class DIDDocumentWithSeq {
+  @Expose()
+  @Type(() => DIDDocument)
+  public readonly document: DIDDocument;
 
-  //TODO @youngjoon-lee: to be type-safe
-  constructor(data: Record<string, any>) {
-    this.id = data.id;
-    this.publicKey = data.publicKey;
-    this.authentication = data.authentication;
+  @Expose()
+  @Transform(s => Number(s), {toClassOnly: true})
+  @Transform(n => n.toString(), {toPlainOnly: true})
+  public readonly sequence: number;
+
+  constructor(document: DIDDocument, sequence: number) {
+    this.document = document;
+    this.sequence = sequence;
   }
 }
 
-export class DIDPubKey {
+export class DIDDocument {
+  @Expose({name: '@context'})
+  @Transform(v => (Array.isArray(v) ? v : [v]), {toClassOnly: true})
+  @Transform(v => (v.length === 1 ? v[0] : v), {toPlainOnly: true})
+  public contexts: string[];
+
+  @Expose()
+  public readonly id: string;
+
+  @Expose()
+  @Type(() => DIDVerificationMethod)
+  public verificationMethod: DIDVerificationMethod[];
+
+  @Expose()
+  // NOTE: @Transform shouldn't be used along with @Type, if you want '{excludeExtraneousValues: true}'.
+  @Transform(l => l.map(DIDAuthentication.fromPlain), {toClassOnly: true})
+  @Transform(l => l.map(DIDAuthentication.toPlain), {toPlainOnly: true})
+  public authentication: DIDAuthentication[];
+
+  constructor(contexts: string[], id: string, verificationMethod: DIDVerificationMethod[], authentication: DIDAuthentication[]) {
+    this.contexts = contexts;
+    this.id = id;
+    this.verificationMethod = verificationMethod;
+    this.authentication = authentication;
+  }
+}
+
+export class DIDVerificationMethod {
+  @Expose()
   public id: string;
+  @Expose()
   public type: string;
+  @Expose()
+  public controller: string;
+  @Expose()
   public publicKeyBase58: string;
 
-  //TODO @youngjoon-lee: to be type-safe
-  constructor(data: Record<string, any>) {
-    this.id = data.id;
-    this.type = data.type;
-    this.publicKeyBase58 = data.publicKeyBase58;
+  constructor(id: string, type: string, controller: string, publicKeyBase58: string) {
+    this.id = id;
+    this.type = type;
+    this.controller = controller;
+    this.publicKeyBase58 = publicKeyBase58;
+  }
+}
+
+export class DIDAuthentication {
+  public veriMethodID: string;
+  public dedicatedVeriMethod?: DIDVerificationMethod;
+
+  constructor(veriMethodID: string, dedicatedVeriMethod?: DIDVerificationMethod) {
+    if (dedicatedVeriMethod && (veriMethodID !== dedicatedVeriMethod.id)) {
+      throw new Error(`id(${veriMethodID}) is different from the ID(${dedicatedVeriMethod.id}) of the dedicated verification method`);
+    }
+
+    this.veriMethodID = veriMethodID;
+    this.dedicatedVeriMethod = dedicatedVeriMethod;
+  }
+
+  // This class cannot be simply transformed by class-transformer annotations
+  static fromPlain(plain: string | Record<string, any>): DIDAuthentication {
+    if (is.string(plain)) {
+      return new DIDAuthentication(plain as string);
+    }
+
+    const veriMethod = plainToClass(DIDVerificationMethod, plain, {excludeExtraneousValues: true});
+    return new DIDAuthentication(veriMethod.id, veriMethod);
+  }
+
+  // This class cannot be simply transformed by class-transformer annotations
+  static toPlain(obj: DIDAuthentication): string | Record<string, any> {
+    if (obj.dedicatedVeriMethod) {
+      return classToPlain(obj.dedicatedVeriMethod);
+    }
+    return obj.veriMethodID;
   }
 }
 
 export const InitialSequence = 0;
+
+/**
+ * Can be serialized for generating a signature for authenticating the DID ownership.
+ * The data can be anything, but the sequence must be specified for preventing replay-attacks.
+ */
+export class DIDSignable {
+  @Expose()
+  public readonly data: any;
+
+  @Expose()
+  @Transform(s => Number(s), {toClassOnly: true})
+  @Transform(n => n.toString(), {toPlainOnly: true})
+  public readonly sequence: number;
+
+  constructor(data: any, sequence: number) {
+    this.data = data;
+    this.sequence = sequence;
+  }
+}

--- a/src/tx/index.ts
+++ b/src/tx/index.ts
@@ -1,4 +1,5 @@
 import is from "is_js";
+import {classToPlain} from "class-transformer";
 import {sortJsonProperties} from '../utils/encoding';
 import base from '../utils';
 import {generateSignatureFromHash, getPublicKeyFromPrivateKey,} from '../crypto';
@@ -10,7 +11,7 @@ export default class Transaction {
   public sequence: string; //TODO @youngjoon-lee: to be number
   public account_number: string; //TODO @youngjoon-lee: to be number
   public chain_id: string;
-  public msgs: any[];    //TODO @youngjoon-lee: to be Message[]
+  public msgs: Record<string, any>[];    //TODO @youngjoon-lee: to be Message[]
   public memo: string;
   public fee: Fee;       //TODO @youngjoon-lee: to be optional, not null
   public signatures: any[];  //TODO @youngjoon-lee: to be Signature[]
@@ -33,9 +34,12 @@ export default class Transaction {
     this.signatures = data.signatures || [];
   }
 
-  addMsgs(...msgs: any): void {
+  addMsgs(...msgs: Record<string, any>[]): void {
     // I hope you fully understand the importance of the message's sequence
-    this.msgs = [...this.msgs, ...msgs];
+    this.msgs = [
+      ...this.msgs,
+      ...msgs.map(msg => classToPlain(msg)),
+    ];
   }
 
   setFee(fee: Fee): void {
@@ -46,7 +50,7 @@ export default class Transaction {
     const sortedJsonTx = sortJsonProperties({
       fee: this.fee,
       memo: this.memo,
-      msgs: this.msgs.map(msg => sortJsonProperties(msg)),
+      msgs: this.msgs,
       sequence: this.sequence.toString(),
       account_number: this.account_number.toString(),
       chain_id: this.chain_id,

--- a/src/utils/did.ts
+++ b/src/utils/did.ts
@@ -1,7 +1,8 @@
-import { DIDDocument, DIDPubKey } from '../message/DID';
+import {DIDDocument, DIDVerificationMethod, DIDSignable, DIDAuthentication} from '../message/DID';
 import { sortJsonProperties } from './encoding';
 import { generateSignatureFromHash } from '../crypto';
 import { sha256 } from './base';
+import {classToPlain} from "class-transformer";
 
 const bs58 = require('bs58');
 
@@ -16,25 +17,18 @@ function generateDID(networkID: string, pubKeyBuf: Buffer) {
 export const generateDIDDocument = (networkID: string, keyIDSuffix: string, pubKeyHex: string): DIDDocument => {
   const pubKeyBuf = Buffer.from(pubKeyHex, 'hex');
 
+  const contexts = ['https://www.w3.org/ns/did/v1'];
   const did = generateDID(networkID, pubKeyBuf);
-  const didPubKey = new DIDPubKey({
-    id: `${did}#${keyIDSuffix}`,
-    type: keyType,
-    publicKeyBase58: bs58.encode(pubKeyBuf),
-  });
+  const didPubKey = new DIDVerificationMethod(`${did}#${keyIDSuffix}`, keyType, did, bs58.encode(pubKeyBuf));
+  const auth = new DIDAuthentication(didPubKey.id)
 
-  return new DIDDocument({
-    id: did,
-    publicKey: [didPubKey],
-    authentication: [didPubKey.id],
-  });
+  return new DIDDocument(contexts, did, [didPubKey], [auth]);
 };
 
 export const sign = (data: any, seq: number, privKey: string): string => {
-  const jsonStr = JSON.stringify(sortJsonProperties({
-    data,
-    sequence: seq.toString(),
-  }));
+  const jsonStr = JSON.stringify(sortJsonProperties(
+    classToPlain(new DIDSignable(data, seq)),
+  ));
   const hash = sha256(Buffer.from(jsonStr).toString('hex'));
   const sigHex = generateSignatureFromHash(hash, privKey);
   return Buffer.from(sigHex, 'hex').toString('base64');

--- a/src/utils/encoding.ts
+++ b/src/utils/encoding.ts
@@ -1,21 +1,34 @@
 import is from "is_js";
+import {classToPlain} from "class-transformer";
 
+/**
+ * Returns a plain object which contains properties sorted by their key (name).
+ * Properties are transformed to the plain object, if they are class objects.
+ *
+ * @param jsonTx - Anything (class object, plain object, primitive values, ...)
+ * @returns The sorted plain object
+ */
 export const sortJsonProperties = (jsonTx: any): any => {
-  if (is.array(jsonTx)) {
+  // Converts the class object to the plain object.
+  // If jsonTx is not a class object, classToPlain does nothing.
+  const plain = classToPlain(jsonTx)
+
+  if (is.array(plain)) {
     return jsonTx.map(sortJsonProperties);
   }
 
   // string or number
-  if (!is.json(jsonTx)) {
+  if (!is.json(plain)) {
     return jsonTx;
   }
 
   const sorted: any = {};
-  Object.keys(jsonTx)
+  Object.keys(plain)
     .sort()
-    .forEach((key) => {
+    .forEach((key: string) => {
       // if (!jsonTx[key]) return;
-      sorted[key] = sortJsonProperties(jsonTx[key]);
+      sorted[key] = sortJsonProperties(plain[key]);
     });
   return sorted;
 };
+

--- a/test/account/index.ts
+++ b/test/account/index.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import { Account, Tx } from '../../src';
 import { test } from '../../src/config';
 

--- a/test/client/Client.ts
+++ b/test/client/Client.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import rewire = require('rewire');
 import config, { test } from '../../src/config';
 import { PARAM } from '../../src/config/default';
@@ -35,26 +36,36 @@ describe('client', () => {
       const testParams = ['abc', 'def'];
       const testQuery = { test1: 'abc', test2: 'def' };
       const client = new Client(test.TEST_URL);
-      return client.getRequest(test.TEST_PARAM_URL, testParams, testQuery)
-        .then(({ error }) => {
-          expect(error.config.url).toEqual(`${test.TEST_URL}${injectParams(test.TEST_PARAM_URL, testParams)}`);
-          expect(error.config.method).toEqual('get');
-          expect(error.config.params).toEqual(testQuery);
-        });
+      expect(client.getRequest(test.TEST_PARAM_URL, testParams, testQuery)).rejects.toMatchObject(
+        {
+          error: {
+            config: {
+              url: `${test.TEST_URL}${injectParams(test.TEST_PARAM_URL, testParams)}`,
+              method: 'get',
+              params: testQuery,
+            }
+          }
+        }
+      );
     });
   });
 
   describe('postRequest', () => {
     it('sends post request', () => {
       const testParams = ['abc', 'def'];
-      const testData = { test1: 'abc', test2: 'def' };
+      const testData = {test1: 'abc', test2: 'def'};
       const client = new Client(test.TEST_URL);
-      return client.postRequest(test.TEST_PARAM_URL, testParams, testData)
-        .then(({ error }) => {
-          expect(error.config.url).toEqual(`${test.TEST_URL}${injectParams(test.TEST_PARAM_URL, testParams)}`);
-          expect(error.config.method).toEqual('post');
-          expect(error.config.data).toEqual(JSON.stringify(testData));
-        });
+      expect(client.postRequest(test.TEST_PARAM_URL, testParams, testData)).rejects.toMatchObject(
+        {
+          error: {
+            config: {
+              url: `${test.TEST_URL}${injectParams(test.TEST_PARAM_URL, testParams)}`,
+              method: 'post',
+              data: JSON.stringify(testData),
+            }
+          }
+        }
+      );
     });
   });
 });

--- a/test/coin/coin.ts
+++ b/test/coin/coin.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import { Coin } from '../../src';
 import { DEFAULT_DENOM } from '../../src/config/default';
 

--- a/test/coin/fee.ts
+++ b/test/coin/fee.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import { Fee } from '../../src';
 import { DEFAULT_DENOM, DEFAULT_GAS } from '../../src/config/default';
 

--- a/test/crypto/index.ts
+++ b/test/crypto/index.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import * as fs from 'fs';
 import * as bip39 from 'bip39';
 import { PRIVKEY_LEN, PRIVKEY_MAX } from '../../src/config/default';

--- a/test/encoding/decode.ts
+++ b/test/encoding/decode.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import { encoding } from '../../src';
 
 const { decodeTx } = encoding;

--- a/test/encoding/encode.ts
+++ b/test/encoding/encode.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import { encoding, Message } from '../../src';
 
 const { encodeTx } = encoding;

--- a/test/message/AOL.ts
+++ b/test/message/AOL.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import config, { test } from '../../src/config';
 import { Message } from '../../src';
 

--- a/test/message/Base.ts
+++ b/test/message/Base.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import config, { test } from '../../src/config';
 import { BaseMessage as Base } from '../../src';
 

--- a/test/message/DID.ts
+++ b/test/message/DID.ts
@@ -1,5 +1,7 @@
+import 'reflect-metadata';  // for class-transformer
 import config, { test } from '../../src/config';
 import { Message } from '../../src';
+import {classToPlain, plainToClass} from "class-transformer";
 
 const { DID } = Message;
 
@@ -11,7 +13,7 @@ describe('DID message', () => {
       expect(msg.type).toEqual(config.MSG_TYPE.DID.CREATE_DID);
       expect(msg.value.did).toEqual(test.MESSAGE.DID.CREATE_DID.did);
       expect(msg.value.document).toEqual(test.MESSAGE.DID.CREATE_DID.document);
-      expect(msg.value.sig_key_id).toEqual(test.MESSAGE.DID.CREATE_DID.sigKeyId);
+      expect(msg.value.verification_method_id).toEqual(test.MESSAGE.DID.CREATE_DID.verificationMethodId);
       expect(msg.value.signature).toEqual(test.MESSAGE.DID.CREATE_DID.signature);
       expect(msg.value.from_address).toEqual(test.MESSAGE.DID.CREATE_DID.fromAddress);
     });
@@ -24,7 +26,7 @@ describe('DID message', () => {
       expect(msg.type).toEqual(config.MSG_TYPE.DID.UPDATE_DID);
       expect(msg.value.did).toEqual(test.MESSAGE.DID.UPDATE_DID.did);
       expect(msg.value.document).toEqual(test.MESSAGE.DID.UPDATE_DID.document);
-      expect(msg.value.sig_key_id).toEqual(test.MESSAGE.DID.UPDATE_DID.sigKeyId);
+      expect(msg.value.verification_method_id).toEqual(test.MESSAGE.DID.UPDATE_DID.verificationMethodId);
       expect(msg.value.signature).toEqual(test.MESSAGE.DID.UPDATE_DID.signature);
       expect(msg.value.from_address).toEqual(test.MESSAGE.DID.UPDATE_DID.fromAddress);
     });
@@ -36,9 +38,28 @@ describe('DID message', () => {
 
       expect(msg.type).toEqual(config.MSG_TYPE.DID.DEACTIVATE_DID);
       expect(msg.value.did).toEqual(test.MESSAGE.DID.DEACTIVATE_DID.did);
-      expect(msg.value.sig_key_id).toEqual(test.MESSAGE.DID.DEACTIVATE_DID.sigKeyId);
+      expect(msg.value.verification_method_id).toEqual(test.MESSAGE.DID.DEACTIVATE_DID.verificationMethodId);
       expect(msg.value.signature).toEqual(test.MESSAGE.DID.DEACTIVATE_DID.signature);
       expect(msg.value.from_address).toEqual(test.MESSAGE.DID.DEACTIVATE_DID.fromAddress);
+    });
+  });
+
+  describe('DID classes transformation', () => {
+    it('converts a DIDDocumentWithSeq to the plain object', () => {
+      const docWithSeq = new Message.DID.DIDDocumentWithSeq(test.SIMPLE_DID_DOC, 100);
+      expect(classToPlain(docWithSeq)).toEqual({
+        document: test.SIMPLE_DID_DOC_PLAIN,
+        sequence: '100',
+      });
+    });
+
+    it('converts a plain object to the DIDDocumentWithSeq', () => {
+      const plain = {
+        document: test.SIMPLE_DID_DOC_PLAIN,
+        sequence: '100',
+      }
+      const expected = new Message.DID.DIDDocumentWithSeq(test.SIMPLE_DID_DOC, 100);
+      expect(plainToClass(Message.DID.DIDDocumentWithSeq, plain, {excludeExtraneousValues: true})).toEqual(expected);
     });
   });
 });

--- a/test/message/Distribution.ts
+++ b/test/message/Distribution.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import config, { test } from '../../src/config';
 import { Message } from '../../src';
 

--- a/test/message/Slashing.ts
+++ b/test/message/Slashing.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import config, { test } from '../../src/config';
 import { Message } from '../../src';
 

--- a/test/message/Staking.ts
+++ b/test/message/Staking.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import config, { test } from '../../src/config';
 import { Message } from '../../src';
 

--- a/test/tx/index.ts
+++ b/test/tx/index.ts
@@ -1,3 +1,4 @@
+import 'reflect-metadata';  // for class-transformer
 import config, { test } from '../../src/config';
 import { Tx, BaseMessage as Msg, Fee } from '../../src';
 


### PR DESCRIPTION
Previously,
the `handleResponse` function in the `Client.ts` has returned a `Promise` with three different kinds of values:
- A data when the HTTP request is succeeded.
- A `{error: {...}}` object when the HTTP request is failed.
- A `{status: .., statusText: .., error: ..}` when the HTTP request is failed.

Also, the `Promise` is never rejected. It's always resolved, even if the HTTP request is failed.
This strategy is not good for usability in the client-side. It makes clients check whether the resolved value is a data or an error object.

In this PR,
I made the `Promise` rejected with `{error: {...}}` or `{status: .., statusText: .., error: ..}`, when HTTP request is failed. 
The data is returned only when HTTP is succeeded and the `Promise` is resolved.
In the future, we can make the `Promise` type-safe (eg. `Promise<DIDDocument>`).