### PR TITLE
feat: stargate: Enable the full 'strict' type mode

### DIFF
--- a/src/group-signing-panacea-client.spec.ts
+++ b/src/group-signing-panacea-client.spec.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import { TextEncoder } from "util";
 import Long from "long";
 import { Secp256k1HdWallet } from "@cosmjs/amino";
+import assert from "assert";
 
 describe("GroupSigningPanaceaClient", () => {
   pendingWithoutPanacead();
@@ -93,6 +94,7 @@ describe("GroupSigningPanaceaClient", () => {
         expect(res).toBeTruthy();
 
         const record = await client.getPanaceaClient().getRecord(ownerAddress, topicName, Long.fromInt(0));
+        assert(record);
         expect(record.writerAddress).toEqual(writerAddress);
         expect(record.key).toEqual(key);
         expect(record.value).toEqual(value);

--- a/src/group-signing-panacea-client.ts
+++ b/src/group-signing-panacea-client.ts
@@ -106,8 +106,10 @@ export class GroupSigningPanaceaClient extends SigningPanaceaClient {
     memo: string,
     explicitSignerDatas?: SignerData[],
   ): Promise<TxRaw> {
-    let signerDatas: SignerData[] = explicitSignerDatas;
-    if (!signerDatas) {
+    let signerDatas: SignerData[];
+    if (explicitSignerDatas) {
+      signerDatas = explicitSignerDatas;
+    } else {
       // Retrieve 'SignerData's from the chain.
       const chainId = await this.getChainId();
       signerDatas = await Promise.all(

--- a/src/signing-panacea-client.spec.ts
+++ b/src/signing-panacea-client.spec.ts
@@ -8,6 +8,7 @@ import { DIDDocument } from "./proto/panacea/did/v2/did";
 import { isBroadcastTxSuccess } from "@cosmjs/stargate";
 import { Secp256k1 } from "./crypto/secp256k1";
 import { DidUtil } from "./did/util";
+import assert from "assert";
 
 describe("SigningPanaceaClient", () => {
   pendingWithoutPanacead();
@@ -51,6 +52,7 @@ describe("SigningPanaceaClient", () => {
         expect(res).toBeTruthy();
 
         const topic = await client.getPanaceaClient().getTopic(ownerAddress, topicName);
+        assert(topic);
         expect(topic.description).toEqual("description!");
       });
     });
@@ -62,6 +64,7 @@ describe("SigningPanaceaClient", () => {
         expect(res).toBeTruthy();
 
         const writer = await client.getPanaceaClient().getWriter(ownerAddress, topicName, writerAddress);
+        assert(writer);
         expect(writer.moniker).toEqual("jack");
         expect(writer.description).toEqual("hello");
       });
@@ -82,6 +85,7 @@ describe("SigningPanaceaClient", () => {
         expect(res).toBeTruthy();
 
         const record = await client.getPanaceaClient().getRecord(ownerAddress, topicName, Long.fromInt(0));
+        assert(record);
         expect(record.writerAddress).toEqual(writerAddress);
         expect(record.key).toEqual(key);
         expect(record.value).toEqual(value);
@@ -128,6 +132,7 @@ describe("SigningPanaceaClient", () => {
       expect(isBroadcastTxSuccess(res)).toBeTruthy();
 
       const didDocumentWithSeq = await client.getPanaceaClient().getDid(didDocument.id);
+      assert(didDocumentWithSeq);
       expect(didDocumentWithSeq.document).toEqual(didDocument);
     });
 
@@ -155,6 +160,7 @@ describe("SigningPanaceaClient", () => {
         expect(isBroadcastTxSuccess(res)).toBeTruthy();
 
         const didDocumentWithSeq = await client.getPanaceaClient().getDid(didDocument.id);
+        assert(didDocumentWithSeq);
         expect(didDocumentWithSeq.document).toEqual(didDocument);
       });
 

--- a/src/signing-panacea-client.ts
+++ b/src/signing-panacea-client.ts
@@ -113,8 +113,8 @@ export class SigningPanaceaClient extends SigningStargateClient {
     super(tmClient, signer, options);
 
     // Build a PanaceaFeeTable
-    const { panaceaGasLimits = panaceaDefaultGasLimits } = options; // Use the default one, if not specified
-    this.panaceaFees = buildFeeTable(options.gasPrice, panaceaDefaultGasLimits, panaceaGasLimits)
+    const { gasPrice = panaceaDefaultGasPrice, panaceaGasLimits = panaceaDefaultGasLimits } = options; // Use the default one, if not specified
+    this.panaceaFees = buildFeeTable(gasPrice, panaceaDefaultGasLimits, panaceaGasLimits)
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,18 +22,17 @@
     "removeComments": true,                   /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-     "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
-    "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
-    //TODO: to be true, after making all codes type-safe
-    "strictNullChecks": false,                /* Enable strict null checks. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    "noImplicitThis": true,                   /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */


### PR DESCRIPTION
Previously, some 'strict type' modes were false because of some legacy Javascript codes. But now, we've removed all legacy Javascript codes. So, we can turn on the full strict type mode: https://www.typescriptlang.org/tsconfig#strict