### PR TITLE
fix: stargate: Use HTTP instead of WebSocket for Tendermint RPC

### DIFF
--- a/src/testutils.ts
+++ b/src/testutils.ts
@@ -1,5 +1,5 @@
 export const panacead = {
-  tendermintUrl: "localhost:26657",
+  tendermintUrl: "http://localhost:26657",
   chainId: "testing",
   genesisAccountMnemonic: "bulb rail shoot abandon eye domain injury return dash away base retreat vote solve recall glass joy neck cabin volcano enemy tribe output nominee",
 }


### PR DESCRIPTION
If the URL string doesn't have a `http://` or `https://` prefix, the CosmJS connects to Tendermint via WebSocket: https://github.com/medibloc/cosmjs/blob/5ee3f82b83c0d2ec12ce1f73d5a19781f343d2f2/packages/tendermint-rpc/src/tendermint34/tendermint34client.ts#L22.
Then, the following warning occurs when running Jest:

> Jest did not exit one second after the test run has completed.
This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.